### PR TITLE
#3 [FEATURE] 파트너 포스팅 관련 API 구현

### DIFF
--- a/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
@@ -15,22 +15,8 @@ public enum BaseResponseStatus {
 	 **/
 	SUCCESS(HttpStatus.OK, true, 200, "요청에 성공했습니다."),
 
-	/**
-	 * 400 : security 에러
-	 */
-	WRONG_JWT_TOKEN(HttpStatus.UNAUTHORIZED, false, 401, "다시 로그인 해주세요"),
-
-	// Members
-	DUPLICATED_NICKNAME(HttpStatus.CONFLICT, false, 2100, "사용중인 닉네임입니다."),
-	DUPLICATED_MEMBERS(HttpStatus.CONFLICT, false, 409, "이미 가입된 멤버입니다."),
-	MASSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 2102, "인증번호 전송에 실패했습니다."),
-	MESSAGE_VALID_FAILED(HttpStatus.UNAUTHORIZED, false, 401, "인증번호가 일치하지 않습니다."),
-	FAILED_TO_LOGIN(HttpStatus.UNAUTHORIZED, false, 401, "아이디 또는 패스워드를 다시 확인하세요."),
-	WITHDRAWAL_MEMBERS(HttpStatus.FORBIDDEN, false, 2105, "탈퇴한 회원입니다."),
-	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다."),
-	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다.");
-
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 포스팅입니다."),
+	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/com/mfc/sns/posting/application/PostService.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostService.java
@@ -2,8 +2,10 @@ package com.mfc.sns.posting.application;
 
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
+import com.mfc.sns.posting.dto.resp.PostListRespDto;
 
 public interface PostService {
 	void createPost(String uuid, UpdatePostReqDto dto);
-	PostDetailRespDto getPost(Long postId);
+	PostDetailRespDto getPostDetail(Long postId);
+	PostListRespDto getPostList(String partnerId);
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostService.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostService.java
@@ -1,5 +1,6 @@
 package com.mfc.sns.posting.application;
 
+import com.mfc.sns.posting.dto.req.DeletePostReqDto;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
 import com.mfc.sns.posting.dto.resp.PostListRespDto;
@@ -8,4 +9,5 @@ public interface PostService {
 	void createPost(String uuid, UpdatePostReqDto dto);
 	PostDetailRespDto getPostDetail(Long postId);
 	PostListRespDto getPostList(String partnerId);
+	void deletePosts(String uuid, DeletePostReqDto dto);
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostService.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostService.java
@@ -10,4 +10,5 @@ public interface PostService {
 	PostDetailRespDto getPostDetail(Long postId);
 	PostListRespDto getPostList(String partnerId);
 	void deletePosts(String uuid, DeletePostReqDto dto);
+	void updatePost(Long postId, String partnerId, UpdatePostReqDto dto);
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostService.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostService.java
@@ -1,7 +1,9 @@
 package com.mfc.sns.posting.application;
 
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
 
 public interface PostService {
 	void createPost(String uuid, UpdatePostReqDto dto);
+	PostDetailRespDto getPost(Long postId);
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostService.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostService.java
@@ -1,0 +1,7 @@
+package com.mfc.sns.posting.application;
+
+import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+
+public interface PostService {
+	void createPost(String uuid, UpdatePostReqDto dto);
+}

--- a/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
@@ -6,14 +6,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.sns.common.exception.BaseException;
-import com.mfc.sns.common.response.BaseResponseStatus;
 import com.mfc.sns.posting.domain.Post;
 import com.mfc.sns.posting.domain.Tag;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
+import com.mfc.sns.posting.dto.resp.PostDto;
+import com.mfc.sns.posting.dto.resp.PostListRespDto;
 import com.mfc.sns.posting.dto.resp.TagDto;
-import com.mfc.sns.posting.infrasturctual.PostRepository;
-import com.mfc.sns.posting.infrasturctual.TagRepository;
+import com.mfc.sns.posting.infrastructure.PostRepository;
+import com.mfc.sns.posting.infrastructure.TagRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,7 +43,7 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public PostDetailRespDto getPost(Long postId) {
+	public PostDetailRespDto getPostDetail(Long postId) {
 		Post post = postRepository.findById(postId)
 				.orElseThrow(() -> new BaseException(POST_NOT_FOUND));
 
@@ -53,7 +54,18 @@ public class PostServiceImpl implements PostService {
 				.bookmarkCnt(post.getBookmarkCnt())
 				.tags(tagRepository.findByPostId(postId)
 						.stream()
-						.map(tag -> new TagDto(tag.getId(), tag.getValue()))
+						.map(TagDto::new)
+						.toList())
+				.build();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PostListRespDto getPostList(String partnerId) {
+		return PostListRespDto.builder()
+				.posts(postRepository.findByPartnerId(partnerId)
+						.stream()
+						.map(PostDto::new)
 						.toList())
 				.build();
 	}

--- a/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.mfc.sns.common.exception.BaseException;
 import com.mfc.sns.posting.domain.Post;
 import com.mfc.sns.posting.domain.Tag;
+import com.mfc.sns.posting.dto.req.DeletePostReqDto;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
 import com.mfc.sns.posting.dto.resp.PostDto;
@@ -68,5 +69,11 @@ public class PostServiceImpl implements PostService {
 						.map(PostDto::new)
 						.toList())
 				.build();
+	}
+
+	@Override
+	public void deletePosts(String uuid, DeletePostReqDto dto) {
+		tagRepository.deleteTags(dto.getPosts());
+		postRepository.deletePosts(dto.getPosts());
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
@@ -1,11 +1,17 @@
 package com.mfc.sns.posting.application;
 
+import static com.mfc.sns.common.response.BaseResponseStatus.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.mfc.sns.common.exception.BaseException;
+import com.mfc.sns.common.response.BaseResponseStatus;
 import com.mfc.sns.posting.domain.Post;
 import com.mfc.sns.posting.domain.Tag;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+import com.mfc.sns.posting.dto.resp.PostDetailRespDto;
+import com.mfc.sns.posting.dto.resp.TagDto;
 import com.mfc.sns.posting.infrasturctual.PostRepository;
 import com.mfc.sns.posting.infrasturctual.TagRepository;
 
@@ -32,5 +38,23 @@ public class PostServiceImpl implements PostService {
 								.value(tag)
 								.post(post)
 								.build()));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PostDetailRespDto getPost(Long postId) {
+		Post post = postRepository.findById(postId)
+				.orElseThrow(() -> new BaseException(POST_NOT_FOUND));
+
+		return PostDetailRespDto.builder()
+				.postId(postId)
+				.imageUrl(post.getImageUrl())
+				.alt(post.getAlt())
+				.bookmarkCnt(post.getBookmarkCnt())
+				.tags(tagRepository.findByPostId(postId)
+						.stream()
+						.map(tag -> new TagDto(tag.getId(), tag.getValue()))
+						.toList())
+				.build();
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
@@ -2,6 +2,8 @@ package com.mfc.sns.posting.application;
 
 import static com.mfc.sns.common.response.BaseResponseStatus.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,11 +37,7 @@ public class PostServiceImpl implements PostService {
 				.bookmarkCnt(0)
 				.build());
 
-		dto.getTags().stream()
-				.forEach(tag -> tagRepository.save(Tag.builder()
-								.value(tag)
-								.post(post)
-								.build()));
+		insertTags(dto.getTags(), post);
 	}
 
 	@Override
@@ -75,5 +73,30 @@ public class PostServiceImpl implements PostService {
 	public void deletePosts(String uuid, DeletePostReqDto dto) {
 		tagRepository.deleteTags(dto.getPosts());
 		postRepository.deletePosts(dto.getPosts());
+	}
+
+	@Override
+	public void updatePost(Long postId, String partnerId, UpdatePostReqDto dto) {
+		Post post = postRepository.findByIdAndPartnerId(postId, partnerId)
+				.orElseThrow(() -> new BaseException(POST_NOT_FOUND));
+
+		tagRepository.deleteTagsByPostId(postId);
+		postRepository.save(Post.builder()
+				.id(postId)
+				.imageUrl(dto.getImageUrl())
+				.alt(post.getAlt())
+				.bookmarkCnt(post.getBookmarkCnt())
+				.build()
+		);
+
+		insertTags(dto.getTags(), post);
+	}
+
+	private void insertTags(List<String> tags, Post post) {
+		tags
+				.forEach(tag -> tagRepository.save(Tag.builder()
+						.value(tag)
+						.post(post)
+						.build()));
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/PostServiceImpl.java
@@ -1,0 +1,36 @@
+package com.mfc.sns.posting.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.sns.posting.domain.Post;
+import com.mfc.sns.posting.domain.Tag;
+import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+import com.mfc.sns.posting.infrasturctual.PostRepository;
+import com.mfc.sns.posting.infrasturctual.TagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostServiceImpl implements PostService {
+	private final PostRepository postRepository;
+	private final TagRepository tagRepository;
+
+	@Override
+	public void createPost(String uuid, UpdatePostReqDto dto) {
+		Post post = postRepository.save(Post.builder()
+				.imageUrl(dto.getImageUrl())
+				.partnerId(uuid)
+				.alt(uuid + "post")
+				.bookmarkCnt(0)
+				.build());
+
+		dto.getTags().stream()
+				.forEach(tag -> tagRepository.save(Tag.builder()
+								.value(tag)
+								.post(post)
+								.build()));
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/domain/Bookmark.java
+++ b/src/main/java/com/mfc/sns/posting/domain/Bookmark.java
@@ -1,0 +1,27 @@
+package com.mfc.sns.posting.domain;
+
+import com.mfc.sns.common.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Bookmark extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String userId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id")
+	private Post post;
+}

--- a/src/main/java/com/mfc/sns/posting/domain/Post.java
+++ b/src/main/java/com/mfc/sns/posting/domain/Post.java
@@ -1,0 +1,36 @@
+package com.mfc.sns.posting.domain;
+
+import static jakarta.persistence.GenerationType.*;
+
+import com.mfc.sns.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Post extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	@Column(updatable = false)
+	private String partnerId;
+	private String imageUrl;
+	private String alt;
+	private Integer bookmarkCnt;
+
+	@Builder
+	public Post(Long id, String partnerId, String imageUrl, String alt, Integer bookmarkCnt) {
+		this.id = id;
+		this.partnerId = partnerId;
+		this.imageUrl = imageUrl;
+		this.alt = alt;
+		this.bookmarkCnt = bookmarkCnt;
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/domain/Tag.java
+++ b/src/main/java/com/mfc/sns/posting/domain/Tag.java
@@ -1,0 +1,37 @@
+package com.mfc.sns.posting.domain;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Tag {
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id")
+	private Post post;
+
+	@Column(length = 10)
+	private String value;
+
+	@Builder
+	public Tag(Long id, Post post, String value) {
+		this.id = id;
+		this.post = post;
+		this.value = value;
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/dto/req/DeletePostReqDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/req/DeletePostReqDto.java
@@ -1,0 +1,11 @@
+package com.mfc.sns.posting.dto.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class DeletePostReqDto {
+	private List<Long> posts = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/sns/posting/dto/req/UpdatePostReqDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/req/UpdatePostReqDto.java
@@ -1,0 +1,12 @@
+package com.mfc.sns.posting.dto.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePostReqDto {
+	private String imageUrl;
+	private List<String> tags = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/PostDetailRespDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/PostDetailRespDto.java
@@ -1,0 +1,18 @@
+package com.mfc.sns.posting.dto.resp;
+
+import java.util.List;
+
+import com.mfc.sns.posting.vo.resp.TagVo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostDetailRespDto {
+	private Long postId;
+	private String imageUrl;
+	private String alt;
+	private int bookmarkCnt;
+	private List<TagDto> tags;
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/PostDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/PostDto.java
@@ -1,0 +1,20 @@
+package com.mfc.sns.posting.dto.resp;
+
+import com.mfc.sns.posting.domain.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostDto {
+	private Long postId;
+	private String imageUrl;
+	private String alt;
+
+	public PostDto(Post post) {
+		this.postId = post.getId();
+		this.imageUrl = post.getImageUrl();
+		this.alt = post.getAlt();
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/PostListRespDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/PostListRespDto.java
@@ -1,0 +1,13 @@
+package com.mfc.sns.posting.dto.resp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostListRespDto {
+	private List<PostDto> posts;
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/TagDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/TagDto.java
@@ -1,11 +1,17 @@
 package com.mfc.sns.posting.dto.resp;
 
+import com.mfc.sns.posting.domain.Tag;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class TagDto {
 	private Long tagId;
 	private String value;
+
+	public TagDto(Tag tag) {
+		this.tagId = tag.getId();
+		this.value = tag.getValue();
+	}
 }

--- a/src/main/java/com/mfc/sns/posting/dto/resp/TagDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/TagDto.java
@@ -1,0 +1,11 @@
+package com.mfc.sns.posting.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TagDto {
+	private Long tagId;
+	private String value;
+}

--- a/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
@@ -1,8 +1,11 @@
-package com.mfc.sns.posting.infrasturctual;
+package com.mfc.sns.posting.infrastructure;
+
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mfc.sns.posting.domain.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+	List<Post> findByPartnerId(String partnerId);
 }

--- a/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
@@ -1,6 +1,7 @@
 package com.mfc.sns.posting.infrastructure;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,8 +10,12 @@ import org.springframework.data.repository.query.Param;
 
 import com.mfc.sns.posting.domain.Post;
 
+import jakarta.ws.rs.POST;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findByPartnerId(String partnerId);
+
+	Optional<Post> findByIdAndPartnerId(Long postId, String partnerId);
 
 	@Modifying(clearAutomatically = true)
 	@Query("delete from Post p where p.id in :posts")

--- a/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/PostRepository.java
@@ -3,9 +3,16 @@ package com.mfc.sns.posting.infrastructure;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.mfc.sns.posting.domain.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findByPartnerId(String partnerId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("delete from Post p where p.id in :posts")
+	void deletePosts(@Param("posts") List<Long> posts);
 }

--- a/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
@@ -1,4 +1,4 @@
-package com.mfc.sns.posting.infrasturctual;
+package com.mfc.sns.posting.infrastructure;
 
 import java.util.List;
 

--- a/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
@@ -3,9 +3,16 @@ package com.mfc.sns.posting.infrastructure;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.mfc.sns.posting.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 	List<Tag> findByPostId(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("delete from Tag t where t.post.id in :posts")
+	void deleteTags(@Param("posts") List<Long> posts);
 }

--- a/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/TagRepository.java
@@ -12,7 +12,11 @@ import com.mfc.sns.posting.domain.Tag;
 public interface TagRepository extends JpaRepository<Tag, Long> {
 	List<Tag> findByPostId(Long postId);
 
-	@Modifying(clearAutomatically = true)
+	@Modifying(flushAutomatically = true)
 	@Query("delete from Tag t where t.post.id in :posts")
 	void deleteTags(@Param("posts") List<Long> posts);
+
+	@Modifying(flushAutomatically = true)
+	@Query("delete from Tag t where t.post.id = :postId")
+	void deleteTagsByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/mfc/sns/posting/infrasturctual/PostRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrasturctual/PostRepository.java
@@ -1,0 +1,8 @@
+package com.mfc.sns.posting.infrasturctual;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mfc.sns.posting.domain.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/mfc/sns/posting/infrasturctual/TagRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrasturctual/TagRepository.java
@@ -1,0 +1,8 @@
+package com.mfc.sns.posting.infrasturctual;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mfc.sns.posting.domain.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/mfc/sns/posting/infrasturctual/TagRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrasturctual/TagRepository.java
@@ -1,8 +1,11 @@
 package com.mfc.sns.posting.infrasturctual;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mfc.sns.posting.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+	List<Tag> findByPostId(Long postId);
 }

--- a/src/main/java/com/mfc/sns/posting/presentation/PostController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/PostController.java
@@ -4,6 +4,8 @@ import static com.mfc.sns.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -15,17 +17,22 @@ import com.mfc.sns.common.response.BaseResponse;
 import com.mfc.sns.posting.application.PostService;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.vo.req.UpdatePostReqVo;
+import com.mfc.sns.posting.vo.resp.PostDetailRespVo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
+@Tag(name = "posts", description = "포스팅 서비스 컨트롤러")
 public class PostController {
 	private final PostService postService;
 	private final ModelMapper modelMapper;
 
 	@PostMapping
+	@Operation(summary = "포스팅 등록 API", description = "이미지 + 태그 업로드")
 	public BaseResponse<Void> createPost(
 			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
 			@RequestBody UpdatePostReqVo vo) {
@@ -33,6 +40,13 @@ public class PostController {
 		checkUuid(uuid);
 		postService.createPost(uuid, modelMapper.map(vo, UpdatePostReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@GetMapping("/{postId}")
+	@Operation(summary = "포스팅 상세 정보 조회 API", description = "각 포스팅 상세 보기")
+	public BaseResponse<PostDetailRespVo> getPost(@PathVariable Long postId) {
+		return new BaseResponse<>(modelMapper.map(
+				postService.getPost(postId), PostDetailRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/sns/posting/presentation/PostController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/PostController.java
@@ -1,0 +1,43 @@
+package com.mfc.sns.posting.presentation;
+
+import static com.mfc.sns.common.response.BaseResponseStatus.*;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.sns.common.exception.BaseException;
+import com.mfc.sns.common.response.BaseResponse;
+import com.mfc.sns.posting.application.PostService;
+import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+import com.mfc.sns.posting.vo.req.UpdatePostReqVo;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+	private final PostService postService;
+	private final ModelMapper modelMapper;
+
+	@PostMapping
+	public BaseResponse<Void> createPost(
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestBody UpdatePostReqVo vo) {
+
+		checkUuid(uuid);
+		postService.createPost(uuid, modelMapper.map(vo, UpdatePostReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	private void checkUuid(String uuid) {
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/presentation/PostController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/PostController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -67,6 +68,16 @@ public class PostController {
 			@RequestBody DeletePostReqVo vo) {
 		checkUuid(uuid);
 		postService.deletePosts(uuid, modelMapper.map(vo, DeletePostReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/{postId}")
+	@Operation(summary = "포스팅 수정 API", description = "포스팅 수정")
+	public BaseResponse<Void> updatePost(@PathVariable Long postId,
+			@RequestHeader(name = "UUID", defaultValue = "") String partnerId,
+			@RequestBody UpdatePostReqVo vo) {
+		checkUuid(partnerId);
+		postService.updatePost(postId, partnerId, modelMapper.map(vo, UpdatePostReqDto.class));
 		return new BaseResponse<>();
 	}
 

--- a/src/main/java/com/mfc/sns/posting/presentation/PostController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/PostController.java
@@ -18,9 +18,11 @@ import com.mfc.sns.posting.application.PostService;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
 import com.mfc.sns.posting.vo.req.UpdatePostReqVo;
 import com.mfc.sns.posting.vo.resp.PostDetailRespVo;
+import com.mfc.sns.posting.vo.resp.PostListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Path;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -46,7 +48,14 @@ public class PostController {
 	@Operation(summary = "포스팅 상세 정보 조회 API", description = "각 포스팅 상세 보기")
 	public BaseResponse<PostDetailRespVo> getPost(@PathVariable Long postId) {
 		return new BaseResponse<>(modelMapper.map(
-				postService.getPost(postId), PostDetailRespVo.class));
+				postService.getPostDetail(postId), PostDetailRespVo.class));
+	}
+
+	@GetMapping("/list/{partnerId}")
+	@Operation(summary = "파트너 별 포스팅 목록 조회 API", description = "파트너 별 포스팅 목록 (무한 스크롤?)")
+	public BaseResponse<PostListRespVo> getPostList(@PathVariable String partnerId) {
+		return new BaseResponse<>(modelMapper.map(
+				postService.getPostList(partnerId), PostListRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/sns/posting/presentation/PostController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/PostController.java
@@ -4,6 +4,7 @@ import static com.mfc.sns.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,14 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mfc.sns.common.exception.BaseException;
 import com.mfc.sns.common.response.BaseResponse;
 import com.mfc.sns.posting.application.PostService;
+import com.mfc.sns.posting.dto.req.DeletePostReqDto;
 import com.mfc.sns.posting.dto.req.UpdatePostReqDto;
+import com.mfc.sns.posting.vo.req.DeletePostReqVo;
 import com.mfc.sns.posting.vo.req.UpdatePostReqVo;
 import com.mfc.sns.posting.vo.resp.PostDetailRespVo;
 import com.mfc.sns.posting.vo.resp.PostListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.ws.rs.Path;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -46,16 +48,26 @@ public class PostController {
 
 	@GetMapping("/{postId}")
 	@Operation(summary = "포스팅 상세 정보 조회 API", description = "각 포스팅 상세 보기")
-	public BaseResponse<PostDetailRespVo> getPost(@PathVariable Long postId) {
+	public BaseResponse<PostDetailRespVo> getPostDetail(@PathVariable Long postId) {
 		return new BaseResponse<>(modelMapper.map(
 				postService.getPostDetail(postId), PostDetailRespVo.class));
 	}
 
 	@GetMapping("/list/{partnerId}")
-	@Operation(summary = "파트너 별 포스팅 목록 조회 API", description = "파트너 별 포스팅 목록 (무한 스크롤?)")
+	@Operation(summary = "파트너 별 포스팅 목록 조회 API", description = "파트너 별 포스팅 목록 (페이징 아직 안함..)")
 	public BaseResponse<PostListRespVo> getPostList(@PathVariable String partnerId) {
 		return new BaseResponse<>(modelMapper.map(
 				postService.getPostList(partnerId), PostListRespVo.class));
+	}
+
+	@DeleteMapping
+	@Operation(summary = "포스팅 삭제 API", description = "포스팅 (다중) 삭제")
+	public BaseResponse<Void> deletePosts(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody DeletePostReqVo vo) {
+		checkUuid(uuid);
+		postService.deletePosts(uuid, modelMapper.map(vo, DeletePostReqDto.class));
+		return new BaseResponse<>();
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/sns/posting/vo/req/DeletePostReqVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/req/DeletePostReqVo.java
@@ -1,0 +1,11 @@
+package com.mfc.sns.posting.vo.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class DeletePostReqVo {
+	private List<Long> posts = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/sns/posting/vo/req/UpdatePostReqVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/req/UpdatePostReqVo.java
@@ -1,0 +1,12 @@
+package com.mfc.sns.posting.vo.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePostReqVo {
+	private String imageUrl;
+	private List<String> tags = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/sns/posting/vo/resp/PostDetailRespVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/resp/PostDetailRespVo.java
@@ -1,0 +1,15 @@
+package com.mfc.sns.posting.vo.resp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class PostDetailRespVo {
+	private Long postId;
+	private String imageUrl;
+	private String alt;
+	private int bookmarkCnt;
+	private List<TagVo> tags = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/sns/posting/vo/resp/PostListRespVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/resp/PostListRespVo.java
@@ -1,0 +1,10 @@
+package com.mfc.sns.posting.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class PostListRespVo {
+	private List<PostVo> posts;
+}

--- a/src/main/java/com/mfc/sns/posting/vo/resp/PostVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/resp/PostVo.java
@@ -1,0 +1,10 @@
+package com.mfc.sns.posting.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class PostVo {
+	private Long postId;
+	private String imageUrl;
+	private String alt;
+}

--- a/src/main/java/com/mfc/sns/posting/vo/resp/TagVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/resp/TagVo.java
@@ -1,0 +1,9 @@
+package com.mfc.sns.posting.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class TagVo {
+	private Long tagId;
+	private String value;
+}


### PR DESCRIPTION
## 📣 파트너 포스팅 관련 API 구현
### 📅 2024.05.27
 
 ### 🌵Branch
`feature/posting`  → `develop`

### 📢 Description
 - 파트너 이미지 포스팅 (등록)
 - 파트너 포스팅 수정
 - 파트너 포스팅 다중 삭제
-  파트너 별 이미지 목록 조회 (페이징 적용 X)
 - 파트너 이미지 상세 보기 (이미지 + 태그)

### 💬Issue Number
[#3] - 파트너 포스팅 API 구현

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note

