### PR TITLE
좋아요 & 팔로우 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/src/main/java/com/mfc/sns/common/config/QueryDslConfig.java
+++ b/src/main/java/com/mfc/sns/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.mfc.sns.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
@@ -16,7 +16,9 @@ public enum BaseResponseStatus {
 	SUCCESS(HttpStatus.OK, true, 200, "요청에 성공했습니다."),
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 포스팅입니다."),
-	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다.");
+	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
+	BOOKMARK_CONFLICT(HttpStatus.CONFLICT, false, 409, "이미 좋아요 한 포스팅입니다.");
+
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/sns/common/response/BaseResponseStatus.java
@@ -17,12 +17,12 @@ public enum BaseResponseStatus {
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 포스팅입니다."),
 	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
-	BOOKMARK_CONFLICT(HttpStatus.CONFLICT, false, 409, "이미 좋아요 한 포스팅입니다.");
+	BOOKMARK_CONFLICT(HttpStatus.CONFLICT, false, 409, "이미 좋아요 한 포스팅입니다."),
+	FOLLOW_CONFLICT(HttpStatus.CONFLICT, false, 409, "이미 팔로우 한 파트너입니다.");
 
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;
 	private final int code;
 	private final String message;
-
 }

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
@@ -3,4 +3,5 @@ package com.mfc.sns.posting.application;
 public interface BookmarkService {
 	void createBookmark(Long postId, String userId);
 	void deleteBookmark(Long postId, String userId);
+	boolean isBookmarked(Long postId, String userId);
 }

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
@@ -1,7 +1,12 @@
 package com.mfc.sns.posting.application;
 
+import org.springframework.data.domain.Pageable;
+
+import com.mfc.sns.posting.dto.resp.PostListRespDto;
+
 public interface BookmarkService {
 	void createBookmark(Long postId, String userId);
 	void deleteBookmark(Long postId, String userId);
 	boolean isBookmarked(Long postId, String userId);
+	PostListRespDto getBookmarkList(String userId, Pageable page);
 }

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkService.java
@@ -1,0 +1,6 @@
+package com.mfc.sns.posting.application;
+
+public interface BookmarkService {
+	void createBookmark(Long postId, String userId);
+	void deleteBookmark(Long postId, String userId);
+}

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
@@ -1,0 +1,31 @@
+package com.mfc.sns.posting.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.sns.posting.domain.Bookmark;
+import com.mfc.sns.posting.infrastructure.BookmarkRepository;
+import com.mfc.sns.posting.infrastructure.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookmarkServiceImpl implements BookmarkService {
+	private final BookmarkRepository bookmarkRepository;
+	private final PostRepository postRepository;
+
+	@Override
+	public void createBookmark(Long postId, String userId) {
+		bookmarkRepository.save(Bookmark.builder()
+				.userId(userId)
+				.post(postId)
+				.build());
+	}
+
+	@Override
+	public void deleteBookmark(Long postId, String userId) {
+		bookmarkRepository.deleteByPostId(postId, userId);
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
@@ -14,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BookmarkServiceImpl implements BookmarkService {
 	private final BookmarkRepository bookmarkRepository;
-	private final PostRepository postRepository;
-
 	@Override
 	public void createBookmark(Long postId, String userId) {
 		bookmarkRepository.save(Bookmark.builder()
@@ -27,5 +25,10 @@ public class BookmarkServiceImpl implements BookmarkService {
 	@Override
 	public void deleteBookmark(Long postId, String userId) {
 		bookmarkRepository.deleteByPostId(postId, userId);
+	}
+
+	@Override
+	public boolean isBookmarked(Long postId, String userId) {
+		return bookmarkRepository.findByPostIdAndUserId(postId, userId).isPresent();
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
@@ -1,11 +1,13 @@
 package com.mfc.sns.posting.application;
 
+import static com.mfc.sns.common.response.BaseResponseStatus.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.mfc.sns.common.exception.BaseException;
 import com.mfc.sns.posting.domain.Bookmark;
 import com.mfc.sns.posting.infrastructure.BookmarkRepository;
-import com.mfc.sns.posting.infrastructure.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +18,10 @@ public class BookmarkServiceImpl implements BookmarkService {
 	private final BookmarkRepository bookmarkRepository;
 	@Override
 	public void createBookmark(Long postId, String userId) {
+		if(bookmarkRepository.existsByPostIdAndUserId(postId, userId)) {
+			throw new BaseException(BOOKMARK_CONFLICT);
+		}
+
 		bookmarkRepository.save(Bookmark.builder()
 				.userId(userId)
 				.post(postId)

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
@@ -38,11 +38,13 @@ public class BookmarkServiceImpl implements BookmarkService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public boolean isBookmarked(Long postId, String userId) {
 		return bookmarkRepository.findByPostIdAndUserId(postId, userId).isPresent();
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public PostListRespDto getBookmarkList(String userId, Pageable page) {
 		Slice<PostDto> posts = bookmarkRepository.getPostList(userId, page);
 

--- a/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/BookmarkServiceImpl.java
@@ -2,11 +2,15 @@ package com.mfc.sns.posting.application;
 
 import static com.mfc.sns.common.response.BaseResponseStatus.*;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.sns.common.exception.BaseException;
 import com.mfc.sns.posting.domain.Bookmark;
+import com.mfc.sns.posting.dto.resp.PostDto;
+import com.mfc.sns.posting.dto.resp.PostListRespDto;
 import com.mfc.sns.posting.infrastructure.BookmarkRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -36,5 +40,15 @@ public class BookmarkServiceImpl implements BookmarkService {
 	@Override
 	public boolean isBookmarked(Long postId, String userId) {
 		return bookmarkRepository.findByPostIdAndUserId(postId, userId).isPresent();
+	}
+
+	@Override
+	public PostListRespDto getBookmarkList(String userId, Pageable page) {
+		Slice<PostDto> posts = bookmarkRepository.getPostList(userId, page);
+
+		return PostListRespDto.builder()
+				.posts(posts.getContent())
+				.isLast(posts.isLast())
+				.build();
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/FollowService.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowService.java
@@ -1,10 +1,13 @@
 package com.mfc.sns.posting.application;
 
+import org.springframework.data.domain.Pageable;
+
 import com.mfc.sns.posting.dto.req.FollowReqDto;
-import com.mfc.sns.posting.vo.req.FollowReqVo;
+import com.mfc.sns.posting.dto.resp.FollowListRespDto;
 
 public interface FollowService {
 	void createFollow(String userId, FollowReqDto dto);
 	void deleteFollow(String userId, FollowReqDto dto);
 	boolean isFollowed(String userId, String partnerId);
+	FollowListRespDto getFollowList(String userId, Pageable page);
 }

--- a/src/main/java/com/mfc/sns/posting/application/FollowService.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowService.java
@@ -6,4 +6,5 @@ import com.mfc.sns.posting.vo.req.FollowReqVo;
 public interface FollowService {
 	void createFollow(String userId, FollowReqDto dto);
 	void deleteFollow(String userId, FollowReqDto dto);
+	boolean isFollowed(String userId, String partnerId);
 }

--- a/src/main/java/com/mfc/sns/posting/application/FollowService.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowService.java
@@ -1,0 +1,9 @@
+package com.mfc.sns.posting.application;
+
+import com.mfc.sns.posting.dto.req.FollowReqDto;
+import com.mfc.sns.posting.vo.req.FollowReqVo;
+
+public interface FollowService {
+	void createFollow(String userId, FollowReqDto dto);
+	void deleteFollow(String userId, FollowReqDto dto);
+}

--- a/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
@@ -34,4 +34,9 @@ public class FollowServiceImpl implements FollowService {
 	public void deleteFollow(String userId, FollowReqDto dto) {
 		followRepository.deleteByUserIdAndPartnerId(userId, dto.getPartnerId());
 	}
+
+	@Override
+	public boolean isFollowed(String userId, String partnerId) {
+		return followRepository.existsByUserIdAndPartnerId(userId, partnerId);
+	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
@@ -1,5 +1,9 @@
 package com.mfc.sns.posting.application;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,6 +11,7 @@ import com.mfc.sns.common.exception.BaseException;
 import com.mfc.sns.common.response.BaseResponseStatus;
 import com.mfc.sns.posting.domain.Follow;
 import com.mfc.sns.posting.dto.req.FollowReqDto;
+import com.mfc.sns.posting.dto.resp.FollowListRespDto;
 import com.mfc.sns.posting.infrastructure.FollowRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -38,5 +43,17 @@ public class FollowServiceImpl implements FollowService {
 	@Override
 	public boolean isFollowed(String userId, String partnerId) {
 		return followRepository.existsByUserIdAndPartnerId(userId, partnerId);
+	}
+
+	@Override
+	public FollowListRespDto getFollowList(String userId, Pageable page) {
+		Page<Follow> follows = followRepository.findByUserId(userId, page);
+
+		return FollowListRespDto.builder()
+				.partners(follows.stream()
+						.map(Follow::getPartnerId)
+						.toList())
+				.isLast(follows.isLast())
+				.build();
 	}
 }

--- a/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
+++ b/src/main/java/com/mfc/sns/posting/application/FollowServiceImpl.java
@@ -1,0 +1,37 @@
+package com.mfc.sns.posting.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.sns.common.exception.BaseException;
+import com.mfc.sns.common.response.BaseResponseStatus;
+import com.mfc.sns.posting.domain.Follow;
+import com.mfc.sns.posting.dto.req.FollowReqDto;
+import com.mfc.sns.posting.infrastructure.FollowRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService {
+	private final FollowRepository followRepository;
+
+	@Override
+	public void createFollow(String userId, FollowReqDto dto) {
+		if(followRepository.existsByUserIdAndPartnerId(userId, dto.getPartnerId())) {
+			throw new BaseException(BaseResponseStatus.FOLLOW_CONFLICT);
+		}
+
+		followRepository.save(Follow.builder()
+				.userId(userId)
+				.partnerId(dto.getPartnerId())
+				.build()
+		);
+	}
+
+	@Override
+	public void deleteFollow(String userId, FollowReqDto dto) {
+		followRepository.deleteByUserIdAndPartnerId(userId, dto.getPartnerId());
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/domain/Bookmark.java
+++ b/src/main/java/com/mfc/sns/posting/domain/Bookmark.java
@@ -3,12 +3,10 @@ package com.mfc.sns.posting.domain;
 import com.mfc.sns.common.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,8 +18,11 @@ public class Bookmark extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private String userId;
+	private Long postId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id")
-	private Post post;
+	@Builder
+	public Bookmark(String userId, Long post) {
+		this.userId = userId;
+		this.postId = post;
+	}
 }

--- a/src/main/java/com/mfc/sns/posting/domain/Follow.java
+++ b/src/main/java/com/mfc/sns/posting/domain/Follow.java
@@ -1,0 +1,31 @@
+package com.mfc.sns.posting.domain;
+
+import com.mfc.sns.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Follow extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(nullable = false, length = 50)
+	private String userId;
+	@Column(nullable = false, length = 50)
+	private String partnerId;
+
+	@Builder
+	public Follow(String userId, String partnerId) {
+		this.userId = userId;
+		this.partnerId = partnerId;
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/dto/req/FollowReqDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/req/FollowReqDto.java
@@ -1,0 +1,8 @@
+package com.mfc.sns.posting.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class FollowReqDto {
+	private String partnerId;
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/FollowListRespDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/FollowListRespDto.java
@@ -1,0 +1,13 @@
+package com.mfc.sns.posting.dto.resp;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FollowListRespDto {
+	private List<String> partners;
+	private boolean isLast;
+}

--- a/src/main/java/com/mfc/sns/posting/dto/resp/PostDto.java
+++ b/src/main/java/com/mfc/sns/posting/dto/resp/PostDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PostDto {
 	private String partnerId;
 	private Long postId;

--- a/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
@@ -1,0 +1,14 @@
+package com.mfc.sns.posting.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mfc.sns.posting.domain.Bookmark;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+	@Modifying
+	@Query("DELETE FROM Bookmark b where b.postId = :postId and b.userId = :userId")
+	void deleteByPostId(@Param("postId") Long postId, @Param("userId") String userId);
+}

--- a/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
@@ -15,4 +15,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 	void deleteByPostId(@Param("postId") Long postId, @Param("userId") String userId);
 
 	Optional<Bookmark> findByPostIdAndUserId(Long postId, String userId);
+
+	boolean existsByPostIdAndUserId(Long postId, String userId);
 }

--- a/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
@@ -1,5 +1,7 @@
 package com.mfc.sns.posting.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +13,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 	@Modifying
 	@Query("DELETE FROM Bookmark b where b.postId = :postId and b.userId = :userId")
 	void deleteByPostId(@Param("postId") Long postId, @Param("userId") String userId);
+
+	Optional<Bookmark> findByPostIdAndUserId(Long postId, String userId);
 }

--- a/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/BookmarkRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.mfc.sns.posting.domain.Bookmark;
 
-public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, CustomRepository {
 	@Modifying
 	@Query("DELETE FROM Bookmark b where b.postId = :postId and b.userId = :userId")
 	void deleteByPostId(@Param("postId") Long postId, @Param("userId") String userId);

--- a/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepository.java
@@ -1,0 +1,10 @@
+package com.mfc.sns.posting.infrastructure;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.mfc.sns.posting.dto.resp.PostDto;
+
+public interface CustomRepository {
+	Slice<PostDto> getPostList(String userId, Pageable page);
+}

--- a/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepositoryImpl.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.mfc.sns.posting.infrastructure;
+
+import static com.mfc.sns.posting.domain.QBookmark.*;
+import static com.mfc.sns.posting.domain.QPost.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import com.mfc.sns.posting.dto.resp.PostDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomRepositoryImpl implements CustomRepository {
+	private final JPAQueryFactory query;
+
+	@Override
+	public Slice<PostDto> getPostList(String userId, Pageable page) {
+		List<PostDto> result = query
+				.select(Projections.constructor(PostDto.class,
+						post.partnerId.as("partnerId"),
+						post.id.as("postId"),
+						post.imageUrl.as("imageUrl"),
+						post.alt.as("alt")))
+				.from(bookmark)
+				.join(post)
+				.on(bookmark.postId.eq(post.id))
+				.where(bookmark.userId.eq(userId))
+				.offset(page.getOffset())
+				.limit(page.getPageSize() + 1)
+				.orderBy(bookmark.createdAt.desc())
+				.fetch();
+
+		boolean hasNext = false;
+		if(result.size() > page.getPageSize()) {
+			result.remove(page.getPageSize());
+			hasNext = true;
+		}
+
+		return new SliceImpl<>(result, page, hasNext);
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/infrastructure/FollowRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/FollowRepository.java
@@ -1,5 +1,9 @@
 package com.mfc.sns.posting.infrastructure;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +13,7 @@ import com.mfc.sns.posting.domain.Follow;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 	boolean existsByUserIdAndPartnerId(String userId, String partnerId);
+	Page<Follow> findByUserId(String userId, Pageable page);
 
 	@Modifying
 	@Query("DELETE FROM Follow f where f.userId = :userId and f.partnerId = :partnerId")

--- a/src/main/java/com/mfc/sns/posting/infrastructure/FollowRepository.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/FollowRepository.java
@@ -1,0 +1,16 @@
+package com.mfc.sns.posting.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mfc.sns.posting.domain.Follow;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+	boolean existsByUserIdAndPartnerId(String userId, String partnerId);
+
+	@Modifying
+	@Query("DELETE FROM Follow f where f.userId = :userId and f.partnerId = :partnerId")
+	void deleteByUserIdAndPartnerId(@Param("userId") String userId, @Param("partnerId") String partnerId);
+}

--- a/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.mfc.sns.posting.presentation;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.sns.common.response.BaseResponse;
 import com.mfc.sns.posting.application.BookmarkService;
+import com.mfc.sns.posting.vo.resp.PostListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,4 +38,12 @@ public class BookmarkController {
 		bookmarkService.deleteBookmark(postId, userId);
 		return new BaseResponse<>();
 	}
+
+	@GetMapping("/{postId}")
+	@Operation(summary = "특정 포스팅 좋아요 여부 조회 API", description = "특정 포스팅 좋아요 여부")
+	public BaseResponse<Boolean> isBookmarked(@PathVariable Long postId,
+			@RequestHeader(value = "UUID", required = false) String userId) {
+		return new BaseResponse<>(bookmarkService.isBookmarked(postId, userId));
+	}
+
 }

--- a/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
@@ -1,5 +1,9 @@
 package com.mfc.sns.posting.presentation;
 
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "bookmark", description = "좋아요 서비스 컨트롤러")
 public class BookmarkController {
 	private final BookmarkService bookmarkService;
+	private final ModelMapper modelMapper;
 
 	@PostMapping("/{postId}")
 	@Operation(summary = "포스팅 좋아요 등록 API", description = "포스팅 좋아요 등록")
@@ -46,4 +51,12 @@ public class BookmarkController {
 		return new BaseResponse<>(bookmarkService.isBookmarked(postId, userId));
 	}
 
+	@GetMapping("/list")
+	@Operation(summary = "유저 별 좋아요 목록 조회 API", description = "유저 별 좋아요 한 포스팅 목록")
+	public BaseResponse<PostListRespVo> getBookmarkList(
+			@RequestHeader(value = "UUID", defaultValue = "") String userId,
+			@PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable page) {
+		return new BaseResponse<>(modelMapper.map(
+				bookmarkService.getBookmarkList(userId, page), PostListRespVo.class));
+	}
 }

--- a/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/BookmarkController.java
@@ -1,0 +1,39 @@
+package com.mfc.sns.posting.presentation;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.sns.common.response.BaseResponse;
+import com.mfc.sns.posting.application.BookmarkService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bookmark")
+@Tag(name = "bookmark", description = "좋아요 서비스 컨트롤러")
+public class BookmarkController {
+	private final BookmarkService bookmarkService;
+
+	@PostMapping("/{postId}")
+	@Operation(summary = "포스팅 좋아요 등록 API", description = "포스팅 좋아요 등록")
+	public BaseResponse<Void> createBookmark(@PathVariable Long postId,
+			@RequestHeader(value = "UUID", defaultValue = "") String userId) {
+		bookmarkService.createBookmark(postId, userId);
+		return new BaseResponse<>();
+	}
+
+	@DeleteMapping("/{postId}")
+	@Operation(summary = "포스팅 좋아요 취소 API", description = "포스팅 좋아요 취소")
+	public BaseResponse<Void> deleteBookmark(@PathVariable Long postId,
+			@RequestHeader(value = "UUID", defaultValue = "") String userId) {
+		bookmarkService.deleteBookmark(postId, userId);
+		return new BaseResponse<>();
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
@@ -1,0 +1,56 @@
+package com.mfc.sns.posting.presentation;
+
+import static com.mfc.sns.common.response.BaseResponseStatus.*;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.sns.common.exception.BaseException;
+import com.mfc.sns.common.response.BaseResponse;
+import com.mfc.sns.posting.application.FollowService;
+import com.mfc.sns.posting.dto.req.FollowReqDto;
+import com.mfc.sns.posting.vo.req.FollowReqVo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/follow")
+@Tag(name = "follow", description = "팔로우 서비스 컨트롤러")
+public class FollowController {
+	private final FollowService followService;
+	private final ModelMapper modelMapper;
+
+	@PostMapping
+	@Operation(summary = "파트너 팔로우 등록 API", description = "파트너 팔로우 등록")
+	public BaseResponse<Void> createFollow(
+			@RequestHeader(value = "UUID", defaultValue = "") String userId,
+			@RequestBody FollowReqVo vo) {
+		checkUuid(userId);
+		followService.createFollow(userId, modelMapper.map(vo, FollowReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@DeleteMapping
+	@Operation(summary = "파트너 팔로우 취소 API", description = "파트너 팔로우 취소")
+	public BaseResponse<Void> deleteFollow(
+			@RequestHeader(value = "UUID", defaultValue = "") String userId,
+			@RequestBody FollowReqVo vo) {
+		followService.deleteFollow(userId, modelMapper.map(vo, FollowReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	private void checkUuid(String uuid) {
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+	}
+}

--- a/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
@@ -3,6 +3,9 @@ package com.mfc.sns.posting.presentation;
 import static com.mfc.sns.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +20,7 @@ import com.mfc.sns.common.response.BaseResponse;
 import com.mfc.sns.posting.application.FollowService;
 import com.mfc.sns.posting.dto.req.FollowReqDto;
 import com.mfc.sns.posting.vo.req.FollowReqVo;
+import com.mfc.sns.posting.vo.resp.FollowListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,13 +53,23 @@ public class FollowController {
 		return new BaseResponse<>();
 	}
 
-	@GetMapping("/list")
+	@GetMapping
 	@Operation(summary = "특정 파트너 팔로우 여부 조회 API", description = "특정 파트너 팔로우 여부")
 	public BaseResponse<Boolean> isFollowed(
 			@RequestHeader(value = "UUID", defaultValue = "") String userId,
 			@RequestHeader(value = "partnerId", defaultValue = "") String partnerId) {
 		checkUuid(userId);
 		return new BaseResponse<>(followService.isFollowed(userId, partnerId));
+	}
+
+	@GetMapping("list")
+	@Operation(summary = "유저 별 팔로우 목록 조회 API", description = "유저 별 팔로우 한 파트너 목록")
+	public BaseResponse<FollowListRespVo> getFollowList(
+			@RequestHeader(value = "UUID", defaultValue = "") String userId,
+			@PageableDefault(size = 3, sort = "createdAt", direction = Sort.Direction.DESC) Pageable page) {
+		checkUuid(userId);
+		return new BaseResponse<>(modelMapper.map(
+				followService.getFollowList(userId, page), FollowListRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
+++ b/src/main/java/com/mfc/sns/posting/presentation/FollowController.java
@@ -5,6 +5,7 @@ import static com.mfc.sns.common.response.BaseResponseStatus.*;
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -46,6 +47,15 @@ public class FollowController {
 			@RequestBody FollowReqVo vo) {
 		followService.deleteFollow(userId, modelMapper.map(vo, FollowReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@GetMapping("/list")
+	@Operation(summary = "특정 파트너 팔로우 여부 조회 API", description = "특정 파트너 팔로우 여부")
+	public BaseResponse<Boolean> isFollowed(
+			@RequestHeader(value = "UUID", defaultValue = "") String userId,
+			@RequestHeader(value = "partnerId", defaultValue = "") String partnerId) {
+		checkUuid(userId);
+		return new BaseResponse<>(followService.isFollowed(userId, partnerId));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/sns/posting/vo/req/FollowReqVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/req/FollowReqVo.java
@@ -1,0 +1,8 @@
+package com.mfc.sns.posting.vo.req;
+
+import lombok.Getter;
+
+@Getter
+public class FollowReqVo {
+	private String partnerId;
+}

--- a/src/main/java/com/mfc/sns/posting/vo/resp/FollowListRespVo.java
+++ b/src/main/java/com/mfc/sns/posting/vo/resp/FollowListRespVo.java
@@ -1,0 +1,11 @@
+package com.mfc.sns.posting.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class FollowListRespVo {
+	private List<String> partners;
+	private boolean isLast;
+}


### PR DESCRIPTION
## 📣 좋아요 & 팔로우 관련 API 구현
### 📅 2024.06.15
 
 ### 🌵Branch
`feature/bookmark-follow`  → `develop`

### 📢 Description
 - 좋아요 관련

   - 좋아요 등록 & 취소 API
   - 좋아요 여부 조회 API
   - 유저 별 좋아요를 누른 포스팅 목록 조회

- 팔로우 관련

  -  팔로우 등록 & 취소 API
  -  팔로우 여부 조회 API
   - 유저 별 팔로우 한 파트너 ID 목록 조회

### 💬Issue Number
close #7 

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
- 일단 시간 문제 상 mysql로 구현했습니다,, 추후 mongodb로 개선 예정,, (maybe,,)