### PR TITLE
포스팅 중복 반환 버그 수정

### DIFF
--- a/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepositoryImpl.java
+++ b/src/main/java/com/mfc/sns/posting/infrastructure/CustomRepositoryImpl.java
@@ -68,6 +68,7 @@ public class CustomRepositoryImpl implements CustomRepository {
 				.where(partnerIdIn(partners), tagEq(search))
 				.offset(page.getOffset())
 				.limit(page.getPageSize() + 1)
+				.groupBy(post.id)
 				.orderBy(post.createdAt.desc())
 				.fetch();
 
@@ -99,6 +100,7 @@ public class CustomRepositoryImpl implements CustomRepository {
 				.join(tag)
 				.on(post.id.eq(tag.post.id))
 				.orderBy(orderCases.asc())
+				.groupBy(post.id)
 				.fetch();
 	}
 


### PR DESCRIPTION
## 📣 포스팅 중복 반환 버그 수정
### 📅 2024.06.28
 
 ### 🌵Branch
`feature/fix-explore`  → `develop`

### 📢 Description
- 탐색 탭에서 같은 포스팅이 여러개 반환되는 버그 수정

### 💬Issue Number
close #28 

### 🛠️Type
- [ ] 새로운 기능 추가 
- [x] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
